### PR TITLE
docs: use jsonc syntax highlighting for manifest example

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -9,7 +9,7 @@ The `manifest.json` file contains all extension metadata and configuration. Most
 
 A basic `manifest.json` with just the required fields looks like this:
 
-```json
+```jsonc
 {
   "manifest_version": "0.1", // Manifest spec version this manifest conforms to
   "name": "my-extension", // Machine-readable name (used for CLI, APIs)


### PR DESCRIPTION
The example at the start of `MANIFEST.md` uses `//` comments in a ``​```json`` code block, which are highlighted as errors on GitHub. Change this syntax hint to ``​```jsonc`` (JSON with comments) for better rendering.


---

## Reference

GitHub documents the languages it supports syntax highlighting for in [languages.yml](https://github.com/github-linguist/linguist/blob/1d913bbdff8e31f1dcf0ba6ce482f4edb5715fc7/lib/linguist/languages.yml#L3435) from the `github-liguist` repo, linked [in their docs](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting:~:text=You%20can%20find%20out%20which%20keywords%20are%20valid%20in%20the%20languages%20YAML%20file.).

## Comparison

To see the difference in GitHub's UI, compare the [current version](https://github.com/anthropics/mcpb/blob/2825da1d6a8d094cc5515bdfdd5a72ebf257cc10/MANIFEST.md) on `main` to [this PR's branch](https://github.com/nicolasff/mcpb/blob/9fce5b58d92ec2ffd25b7f78544388340ecef54b/MANIFEST.md).

### Current `main`

<img width="1892" height="1192" alt="Screenshot 2025-09-20 at 07 42 06" src="https://github.com/user-attachments/assets/a4346ae1-92bb-4bab-9006-8bed9369cd2d" />

### This PR

<img width="1892" height="1192" alt="Screenshot 2025-09-20 at 07 42 20" src="https://github.com/user-attachments/assets/1da58687-dc96-4ff9-95db-d49c20aafaf5" />